### PR TITLE
Update Filestore docs to describe new runner file naming

### DIFF
--- a/source/documentation/services/backend-services.html.md.erb
+++ b/source/documentation/services/backend-services.html.md.erb
@@ -91,10 +91,21 @@ Requests should be checked for the presence of `encrypted_user_id_and_token` (as
 
 #### Creating S3 key
 
+The Legacy Runner does:
+
 - Create digest from service token + user id + file fingerprint
 - Encrypt digest via AES-256 with the encrypted_user_id_and_token as key
 - Generate hash of encrypted digest
 - Key is /{service_slug}/{user_id}/{hashed_digest}
+
+The New Runner does:
+
+- Create digest from user id + file fingerprint (no service token)
+- Encrypt digest via AES-256 with the encrypted_user_id_and_token as key
+- Base64 encode the digest
+- Key is {user_id}{hashed_digest} (no / in between and no service_slug)
+
+The difference is only for the name of the file that resides on S3.
 
 #### Store file
 


### PR DESCRIPTION
There is a small difference in the way the Runner creates the
encrypted_user_id_and_token.

It still uses the service secret as the key when encrypting, but the
secret itself is not part of what is being encrypted.

It is also does not use the service slug when creating the final hashed
key.

This is effectively just the name of the file that sits on S3. The file
payload is encrypted in the same way before upload. It is also encyrpted
at rest in the bucket.

The user_id and user_token as also remain encrypted