### PR TITLE
Docs about cross container envar contamination

### DIFF
--- a/source/documentation/services/deployments.html.md.erb
+++ b/source/documentation/services/deployments.html.md.erb
@@ -43,9 +43,17 @@ If however your branch build fails for some reason Jean Luc will express his dis
 
 ### Caveats
 
+#### Shared Database
+
 All the different Editors share the use of the same database. This means that we should be _very_ careful when doing anything that involves database migrations as this can lead to many issues.
 
 Also the Workers containers for all the Editor apps share the same database too. When a Delayed Job (Publishing or Unpublishing) is first created on the database there is no guarantee that the Worker that picks up the job to process it will be running the same code as the app where the Job was actually created. Any of the available Editor apps could be the one to pick up the job and process it.
+
+#### Cross Container Environment Variable Contamination
+
+This one is a bit of tech debt but only relates to the Test environment. As a consequence of having `n` number of Editor containers the `fb-deploy` scripts do not take into account multiple versions of the configurations. Therefore some of Kubernetes default environment variables for the service ports are being set inside all the other containers that are deployed _after_ a testable editor is deployed.
+
+We will fix this at some point, but it does not impact performance directly so has been deprioritised, but developers should be aware.
 
 ### Testable Editor teardown
 


### PR DESCRIPTION
The Editor has some additional envars set in the containers by
kubernetes after deployments.