### PR TITLE
Acceptance Tests documentation

### DIFF
--- a/source/documentation/services/runner.html.md.erb
+++ b/source/documentation/services/runner.html.md.erb
@@ -75,6 +75,49 @@ The resulting token must be passed as a header called `x-access-token`
   - If the token is not present, the response will be 401 Unauthorised
   - If the token is not valid, the response will be 403 Forbidden
 
+
+### Acceptance tests
+
+Acceptance tests for both the new Runner and the Legacy Runner can be found in the [fb-acceptance-tests](https://github.com/ministryofjustice/fb-acceptance-tests) repo. All the forms that are tested against live in the `formbuilder-services-test-dev` namespace.
+
+The Legacy Runner makes use of several forms each broken down to test an individual component. They can be found in the [test Publisher](https://fb-publisher-test.apps.live-1.cloud-platform.service.justice.gov.uk/services?utf8=%E2%9C%93&query=acceptance).
+
+There are quite a few forms:
+
+- Acceptance tests Autocomplete
+- Acceptance tests Checkboxes
+- Acceptance tests Conditional steps
+- Acceptance tests Conditional with upload
+- Acceptance tests Date
+- Acceptance tests Email component form
+- Acceptance tests Email output
+- Acceptance tests Exit page
+- Acceptance tests Fieldset
+- Acceptance tests JSON output
+- Acceptance tests Maintenance mode
+- Acceptance tests Number
+- Acceptance tests Radios
+- Acceptance tests Select
+- Acceptance tests Text
+- Acceptance tests Textarea
+- Acceptance tests Upload
+
+All of the above forms are tested if there are ever any changes deployed to the [fb-runner-node](https://github.com/ministryofjustice/fb-runner-node). Once the containers are deployed and restarted the [deployment pipline](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner-node) will trigger.
+
+The new Runner forms work very differently. There are only two:
+
+- [New Runner Acceptance Tests](https://new-runner-acceptance-tests.dev.test.form.service.justice.gov.uk)
+- [Acceptance Tests Branching Fixture 10](https://acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk)
+
+We do not have any RBAC in place yet for shared permission to the forms to you will have to visit each service URL directly in the Editor:
+
+- [New Runner Acceptance Tests in the Editor](https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/services/cd75ad76-1d4b-4ce5-8a9e-035262cd2683/edit)
+- [Acceptance Tests Branching Fixture 10 in the Editor](https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/services/e68dca75-20b8-468e-9436-e97791a914c5/edit)
+
+Both of the above forms are tested whenever the [fb-runner](https://github.com/ministryofjustice/fb-runner) is deployed. Once the containers are deployed and restarted the [deployment pipline](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner) will trigger.
+
+Any forms that test submission will submit to fb-acceptance-tests@digital.justice.gov.uk. Details of how to access this account can be found in the shared LastPass. The acceptance tests will check the contents of the submission PDF to make sure it was correctly generated.
+
 ###Technology
 - Ruby on Rails
 


### PR DESCRIPTION
This adds documentation around the acceptance tests for both the legacy
Runner and the new Runner.

<img width="530" alt="Screenshot 2022-01-20 at 17 05 14" src="https://user-images.githubusercontent.com/3466862/150386897-befb78b9-77ff-44d2-9f79-940b6beac8dc.png">

