### PR TITLE
Add some overview frontend documentation for Editor

### DIFF
--- a/source/documentation/services/editor-admin-feature.html.md.erb
+++ b/source/documentation/services/editor-admin-feature.html.md.erb
@@ -1,13 +1,11 @@
 ---
 title: Editor Admin Feature
-category: platform
+category: platform-editor
 last_reviewed_on: 2021-11-10
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
-
-## Editor Admin Feature
 
 The Editor Admin Feature is available only to developers in the MoJ Forms team. The feature was added to assist developers with supporting the MOJ Forms service.
 

--- a/source/documentation/services/editor.html.md.erb
+++ b/source/documentation/services/editor.html.md.erb
@@ -17,11 +17,10 @@ A Ruby on Rails app with a custom javascript frontend, that allows you to make c
 * [fb-metadata-api](https://github.com/ministryofjustice/fb-metadata-api)
 
 ## Documentation
-
-* Editor: [Frontend overview](/documentation/services/editor/frontend-overview.html)
-* Editor: HTML/Templates
-* Editor: CSS
-* [Editor: JavaScript](/documentation/services/editor/javascript.html)
-
-
-<br><br>
+<ul>
+    <% sitemap.resources.select { |page| page.path =~ /html$/ }.each do |page| %>
+        <% if page.data.category == "platform-editor" %>
+            <li><a href="<%= page.url %>"><%= page.data.title %></a></li>
+        <% end %>
+    <% end %>
+</ul>

--- a/source/documentation/services/editor/frontend-css.html.md.erb
+++ b/source/documentation/services/editor/frontend-css.html.md.erb
@@ -1,0 +1,53 @@
+---
+title: Editor
+category: platform
+last_reviewed_on: 2022-03-10
+review_in: 3 months
+---
+
+<% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
+
+Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
+
+* * *
+
+
+# CSS
+
+
+Stylesheets can be found starting from `app/javascript/styles` folder. There is a linked in package for Gov.UK CSS but that is not covered within this documentation.
+
+<small>For more information on Gov.UK CSS see the [Gov.UK Design System](https://design-system.service.gov.uk/) documentation.</small>
+
+* Files (.scss)
+
+CSS for the Editor is mainly held within the one file, index.scss. It is likely over time this could be split into smaller, perhaps more controllable chunks but this would be nicety not necessity.
+
+Main aim for Editor CSS is to do things properly, identifying and labelling components through functionality, not visual representation. This provides a more robust and easier to maintain level of organisation. You should know what is being affected. GDS CSS does not do this, choosing instead to organise and identify based on visual requirement and applying multiple, Bootstrap CSS style, visual class names to multiple elements. This can make things very hard to customise and cause severely bloated stylesheets, but the Editor files cannot change or correct for that.
+
+e.g. Editor CSS results in this kind of thing (due to HTML non-visual markup approach):
+
+```
+.branch {
+  @include container_panel;
+  padding: 10px;
+}
+
+.branch-condition {
+  background-color: blue;
+  border: 1px solid grey;
+  margin-bottom: 10px;
+}
+
+.branch-question,
+.branch-answer {
+  width: 50px;
+}
+```
+
+The code tries to maintain an alphabetically ordered approach to property names and selector layouts, putting least specific priority first, but also sectioning components and areas together.
+
+Some components have their own stylesheets but there is plenty more room for more isolated organisation, if that becomes a requirement.
+
+
+<br><br>

--- a/source/documentation/services/editor/frontend-css.html.md.erb
+++ b/source/documentation/services/editor/frontend-css.html.md.erb
@@ -1,19 +1,11 @@
 ---
-title: Editor
-category: platform
+title: Editor - CSS
+category: platform-editor
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
-
-Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
-
-* * *
-
-
-# CSS
-
 
 Stylesheets can be found starting from `app/javascript/styles` folder. There is a linked in package for Gov.UK CSS but that is not covered within this documentation.
 

--- a/source/documentation/services/editor/frontend-html.html.md.erb
+++ b/source/documentation/services/editor/frontend-html.html.md.erb
@@ -1,0 +1,180 @@
+---
+title: Editor
+category: platform
+last_reviewed_on: 2022-04-05
+review_in: 3 months
+---
+
+<% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
+
+Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
+
+* * *
+
+
+# HTML
+
+All templates follow the Rails standard approach of being stored within this `app/views/` folder.
+
+* Templates (.html.erb)
+
+
+## Semantic and lean markup
+
+HTML should be written using minimal, semantic markup with functional identifiers and, where possible, without any need for extra markup targeting visual requirement.
+
+e.g. Preference is for the Editor HTML to do this...
+
+```html
+<div class="branch">
+  ...
+  <div class="branch-condition">
+    <div class="branch-question">
+      ...
+    </div>
+    <div class="branch-answer">
+      ...
+    </div>
+  </div>
+</div>
+```
+
+...rather than this kind of thing:
+
+```html
+<div class="container-panel govuk-grid-column-two-thirds padding-10">
+  ...
+  <div class="bg-blue">
+    <div class="border-outline-intense margin-10">
+      <div class="govuk-!-width-one-half">
+        ...
+      </div>
+      <div class="govuk-!-width-one-half">
+        ...
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Unfortunately, because there is the need to share space with GDS css, we sometimes have unwanted design/visual-based class names present. These should just be minimised for less intrusion and, should the future need arise, to allow the possibility of white-label site opportunity.
+
+
+## Layouts
+
+Files are organised using standard Rails approach, with Layouts, templates, and partials.
+
+A typical `(app/views/layouts/application.html.erb)` layout breakdown might be:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>MoJ Forms</title>
+    % csrf_meta_tags %
+    %= csp_meta_tag %
+    %= render partial: 'partials/head_tags' %
+    %= render partial: 'partials/properties' %
+    %= stylesheet_pack_tag 'application', media: 'all' %
+    %= javascript_pack_tag 'application' %
+  </head>
+
+  <body class="govuk-body %= "#{controller_name}-#{action_name}" %">
+    %= render partial: 'partials/header' %
+
+    <main id="main-content" role="main">
+
+      %= yield %
+
+    </main>
+
+    %= render partial: 'partials/footer' %
+    %= render partial: 'partials/template_dialog' %
+    %= render partial: 'partials/template_dialog_confirmation' %
+    %= render partial: 'partials/template_dialog_confirmation_delete' %
+  </body>
+</html>
+
+```
+
+
+## Partials
+
+Partials are shared snippets of code that can be used across templates and layouts located in `app/views/partials` folder.
+
+One less obvious partial in the layout example, above, is the `partials/properties`. This is a file that is used to pass information from the HTML/template layer to the JavaScript. It essentially just initialises a JavaScript object with lots of properties for later recall.
+
+e.g. app/views/partials/_properties.html.erb
+
+```javascript
+<script>
+  var app = {
+    api: {
+      new_conditional: "/api/services/%= params[:id] %>/branches/%= @branch && @branch.flow_uuid %>/conditionals/#{conditional_index}",
+      get_expression: "/api/services/%= params[:id] %>/components/#{component_id}/conditionals/#{conditionals_index}/expressions/#{expressions_index}"
+    },
+    page: {
+      id: "%= params[:page_uuid] %",
+      action: "%= action_name %",
+      controller:  "%= controller_name %",
+      data_url: "%= yield :page_data_url %"
+    },
+    service: {
+      id: "%= params[:id] %"
+    },
+    text: {
+      aria: {
+        answers: "%= t('aria.answers') %",
+        hint: "%= t('aria.hint') %",
+        question: "%= t('aria.question') %",
+        section_heading: "%= t('aria.section_heading') %"
+      },
+
+  ...
+
+```
+
+Properties set in the above partials can be retrieved in JavaScript.
+
+```html
+<script>
+  console.log(app.text.hint);
+</script>
+```
+
+
+## Views
+
+Views are rendered by the Rails standard approach. The above layout example shows the `yield` keyword placeholder that will be swapped out by the corresponding view.
+
+e.g. For a `BranchesController#edit` action, `yield` will be replaced by the view code located in `app/views/branches/edit.html.erb`
+
+
+## Templates
+
+Lastly, the above layout example shows some partials named `partials/template_xyz...`. These are snippets of HTML used for JavaScript enhanced widgets/components.
+
+e.g. `partials/template_dialog` will inject something like this code into the HTML output:
+
+```html
+<script type="text/html"
+        data-component-template="Dialog"
+        data-classes="dialog-message"
+        data-text-cancel="Cancel"
+        data-text-ok="Ok">
+
+  <div class="component component-dialog" id="dialog">
+    <h3 data-node="heading" class="govuk-label govuk-label--m">
+      General heading here
+    </h3>
+    <p data-node="content">
+      General message here
+    </p>
+  </div>
+</script>
+```
+
+This is a basic piece of HTML picked up by JavaScript code and turned into a reusable Dialog component.
+
+
+<br><br>

--- a/source/documentation/services/editor/frontend-html.html.md.erb
+++ b/source/documentation/services/editor/frontend-html.html.md.erb
@@ -1,18 +1,11 @@
 ---
-title: Editor
-category: platform
+title: Editor - HTML
+category: platform-editor
 last_reviewed_on: 2022-04-05
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
-
-Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
-
-* * *
-
-
-# HTML
 
 All templates follow the Rails standard approach of being stored within this `app/views/` folder.
 

--- a/source/documentation/services/editor/frontend-javascript.html.md.erb
+++ b/source/documentation/services/editor/frontend-javascript.html.md.erb
@@ -1,0 +1,198 @@
+---
+title: Editor
+category: platform
+last_reviewed_on: 2022-03-10
+review_in: 3 months
+---
+
+<% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
+
+Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
+
+* * *
+
+
+# JavaScript
+
+
+JavaScript files can be found in the `app/javascript/src` folder. 
+
+- [GitHub Files \(.js\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/src)
+- [JS Test files](https://github.com/ministryofjustice/fb-editor/tree/main/test)
+
+
+<br>
+## Build
+
+JavaScript starts with creating the `app` namespaced object. It holds certain properties that will setup the data or allow text to be passed from templates to the script files. The most important properties are those that will initiate the required controller and view.
+
+e.g.
+
+```
+var app {
+  page: {
+      action: "new",
+      controller:  "branches",
+      ...
+  }
+  ...
+}
+```
+
+The `app/javascript/src/index.js` file is the next important piece. This file extracts the Controller+Action as a string value and determinds the appropriate Controller class to create a Controller instance. 
+
+The above `app.page` values will result in `BranchesController#new` value, to mirror that used by the Rails backend. Once the type of controller is set, the kick-off line will initiate the JavaScript view build/enhancement using the appropriate controller+action.
+
+```
+$(document).ready( () => new Controller(app) );
+```
+
+Controller in the above would be `new BranchesController(app)` so the next step is to look for the `app/javascript/src/controller_branches.js` file. There is a file for each controller type.
+
+
+<br>
+## View Controllers
+
+Each view will have a corresponding view controller file. The controller and action values used will correspond to the same used by the backend. For the example Branches controller, we'd have something like this:
+
+```
+class BranchesController extends DefaultController {
+
+  constructor(app) {
+    super(app);
+    this.api = app.api;
+
+    switch(app.page.action) {
+      case "new":
+      case "create":
+      case "edit":
+      case "update":
+        this.create();
+    }
+  }
+
+  /* ACTION SETUP:
+   * Setup view for the create (new) action
+   **/
+  create() {
+    var $branches = this.branchNodes;
+    var $injectors = $(BRANCH_INJECTOR_SELECTOR);
+    var $otherwise = $(BRANCH_OTHERWISE_SELECTOR + " " + BRANCH_DESTINATION_SELECTOR);
+
+    this.branchConditionTemplate = createBranchConditionTemplate($branches.eq(0));
+
+    BranchesController.addBranchEventListeners(this)
+    BranchesController.enhanceCurrentBranches.call(this, $branches);
+    BranchesController.enhanceBranchInjectors.call(this, $injectors);
+    BranchesController.enhanceBranchOtherwise.call(this, $otherwise);
+  }
+}
+``` 
+
+In all cases, this controller simply initiates all views using the `create()` function. Other controllers may use separate functions but for all, after this point it's just a case of following the JavaScript to see what a specific controller does.
+
+
+<br>
+## OOP, scripting, and jQuery
+
+A common danger of using jQuery is proliferation of seemingly endless and unstructured scripting style, creating difficult to follow and maintain code. The Editor JavaScript tries to stick closely to Object Oriented Programming techniques to promote better organisation and code reuse, especially seeking to avoid numeroues and repeated jQuery search and find approaches.
+
+However, nothing is so rigid and inflexible to prevent a developer from choosing a preferred choice for any particular task. The expectation of judgement and effort to 'do the right thing' is required but developers are free to choose the right solution. There is no dictating framework or restrictive ruleset.
+
+As a result of this, the code in place is intended to continually evolve and imporove. The goal should always be to seek out repeatable patterns, with reusable components and code. Most important, we aim to keep it simple because things will always become more complicated than originally intended. Less frameworks and less bolt on third-party solutions will equal a lower learning curve and more ability to utilise existing JavScript knowledge.
+
+<br>
+## Common patterns
+
+
+### Creating a component
+
+A common pattern used for all components is to pass a jQuery target node, along with an object for configuration.
+
+e.g.
+
+```
+class Component {
+  #config;
+
+  constructor($node, config) {
+    this.#config = mergeObjects({
+      css_name: "something",
+      max: 3
+    }, config);
+
+    ...
+  }
+
+}
+```
+
+Defaults can be set with ability to override if we use the utilities.mergeObjects function (see above example).
+
+
+### Making the instance available
+
+For all component classes where we pas in a jQuery node, we add a reference to the instance as data on the node. This means we can easily find and use the underlying class instance object even after we've captured the node by a separate jQuery lookup. 
+
+e.g.
+
+```
+class Person {
+  #config;
+
+  constructor($node, config) {
+    this.#config = mergeObjects({
+      name: "",
+      age: 0
+    }, config);
+
+    $node.data("instance", this);
+
+    ...
+  }
+
+}
+
+var $person = $(".person");
+new Person($person, {
+  name: "Fred",
+  age: 20
+});
+
+// later...
+$(".person").data("instance").name; // Returns "Fred" 
+
+```
+
+
+
+<br>
+## Testing
+
+To run all the JavaScript tests:
+
+```
+npm run jstest test
+```
+
+To run a single JavaScript test file:
+
+```
+npm run jstest test/component_dialog_test.js
+```
+
+To run a test with debugging:
+
+- Open Chrome browser and type
+  ```
+  chrome://inspect
+  ```
+
+- Click the link 'Open dedicated DevTools for Node'
+- Add a breakpoint in your code by inserting 'debugger'
+- Run this line to start the test:
+
+  ```
+  ./node_modules/mocha/bin/mocha --inspect test/component_dialog_test.js 
+  ```
+

--- a/source/documentation/services/editor/frontend-javascript.html.md.erb
+++ b/source/documentation/services/editor/frontend-javascript.html.md.erb
@@ -1,21 +1,13 @@
 ---
-title: Editor
-category: platform
+title: Editor - Javascript
+category: platform-editor
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
 
-Category: [Editor](../editor.html) | [Frontend Overview](./frontend-overview.html)
-
-* * *
-
-
-# JavaScript
-
-
-JavaScript files can be found in the `app/javascript/src` folder. 
+JavaScript files can be found in the `app/javascript/src` folder.
 
 - [GitHub Files \(.js\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/src)
 - [JS Test files](https://github.com/ministryofjustice/fb-editor/tree/main/test)
@@ -39,7 +31,7 @@ var app {
 }
 ```
 
-The `app/javascript/src/index.js` file is the next important piece. This file extracts the Controller+Action as a string value and determinds the appropriate Controller class to create a Controller instance. 
+The `app/javascript/src/index.js` file is the next important piece. This file extracts the Controller+Action as a string value and determinds the appropriate Controller class to create a Controller instance.
 
 The above `app.page` values will result in `BranchesController#new` value, to mirror that used by the Rails backend. Once the type of controller is set, the kick-off line will initiate the JavaScript view build/enhancement using the appropriate controller+action.
 
@@ -87,7 +79,7 @@ class BranchesController extends DefaultController {
     BranchesController.enhanceBranchOtherwise.call(this, $otherwise);
   }
 }
-``` 
+```
 
 In all cases, this controller simply initiates all views using the `create()` function. Other controllers may use separate functions but for all, after this point it's just a case of following the JavaScript to see what a specific controller does.
 
@@ -132,7 +124,7 @@ Defaults can be set with ability to override if we use the utilities.mergeObject
 
 ### Making the instance available
 
-For all component classes where we pas in a jQuery node, we add a reference to the instance as data on the node. This means we can easily find and use the underlying class instance object even after we've captured the node by a separate jQuery lookup. 
+For all component classes where we pas in a jQuery node, we add a reference to the instance as data on the node. This means we can easily find and use the underlying class instance object even after we've captured the node by a separate jQuery lookup.
 
 e.g.
 
@@ -160,7 +152,7 @@ new Person($person, {
 });
 
 // later...
-$(".person").data("instance").name; // Returns "Fred" 
+$(".person").data("instance").name; // Returns "Fred"
 
 ```
 
@@ -193,6 +185,6 @@ To run a test with debugging:
 - Run this line to start the test:
 
   ```
-  ./node_modules/mocha/bin/mocha --inspect test/component_dialog_test.js 
+  ./node_modules/mocha/bin/mocha --inspect test/component_dialog_test.js
   ```
 

--- a/source/documentation/services/editor/frontend-overview.html.md.erb
+++ b/source/documentation/services/editor/frontend-overview.html.md.erb
@@ -1,17 +1,11 @@
 ---
-title: Editor
-category: platform
+title: Editor - Frontend Overview
+category: platform-editor
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
-
-Category: [Editor](../editor.html)
-
-* * *
-
-# Frontend Overview
 
 The main bulk of customised Frontend code has been focussed on the [fb-editor](https://github.com/ministryofjustice/fb-editor) project. Supporting views for the [fb-runner](https://github.com/ministryofjustice/fb-runner) are primarily based on standard GDS templates with minimal, if any, tweaks to support [fb-editor](https://github.com/ministryofjustice/fb-editor) requirements.
 
@@ -71,7 +65,7 @@ test/
 
 ## HTML
 
-HTML files can be found in the `app/view` folder. 
+HTML files can be found in the `app/view` folder.
 
 - [GitHub Files \(.html.erb\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/view)
 
@@ -80,7 +74,7 @@ Further information and specific topics on [Editor HTML](frontend-html.html)
 
 ## CSS
 
-Stylesheet files can be found in the `app/javascript/styles` folder. 
+Stylesheet files can be found in the `app/javascript/styles` folder.
 
 - [GitHub Files \(.sass\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/styles)
 
@@ -89,7 +83,7 @@ Further information and specific topics on [Editor CSS](frontend-css.html)
 
 ## JavaScript
 
-JavaScript files can be found in the `app/javascript/src` folder. 
+JavaScript files can be found in the `app/javascript/src` folder.
 
 - [GitHub Files \(.js\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/src)
 - [JS Test files](https://github.com/ministryofjustice/fb-editor/tree/main/test)

--- a/source/documentation/services/editor/frontend-overview.html.md.erb
+++ b/source/documentation/services/editor/frontend-overview.html.md.erb
@@ -11,7 +11,7 @@ Category: [Editor](../editor.html)
 
 * * *
 
-# Frontend Documentation
+# Frontend Overview
 
 The main bulk of customised Frontend code has been focussed on the [fb-editor](https://github.com/ministryofjustice/fb-editor) project. Supporting views for the [fb-runner](https://github.com/ministryofjustice/fb-runner) are primarily based on standard GDS templates with minimal, if any, tweaks to support [fb-editor](https://github.com/ministryofjustice/fb-editor) requirements.
 
@@ -69,38 +69,31 @@ test/
 ```
 
 
-<br>
 ## HTML
 
-All templates follow the Rails standard approach of being stored within this `app/views/` folder.
+HTML files can be found in the `app/view` folder. 
 
-* Templates (.html.erb)
+- [GitHub Files \(.html.erb\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/view)
+
+Further information and specific topics on [Editor HTML](frontend-html.html)
 
 
-<br>
 ## CSS
 
-Stylesheets can be found starting from `app/javascript/styles` folder. There is a linked in package for Gov.UK CSS but that is not covered within this documentation.
+Stylesheet files can be found in the `app/javascript/styles` folder. 
 
-<small>For more information on Gov.UK CSS see the [Gov.UK Design System](https://design-system.service.gov.uk/) documentation.</small>
+- [GitHub Files \(.sass\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/styles)
 
-* Files (.scss)
+Further information and specific topics on [Editor CSS](frontend-css.html)
 
 
-<br>
 ## JavaScript
 
 JavaScript files can be found in the `app/javascript/src` folder. 
 
-[GitHub Files \(.js\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/src)
+- [GitHub Files \(.js\)](https://github.com/ministryofjustice/fb-editor/tree/main/app/javascript/src)
+- [JS Test files](https://github.com/ministryofjustice/fb-editor/tree/main/test)
 
-
-* Setup
-* [Components](/documentation/services/editor/javascript.html#components)
-* Classes
-* Tests
-
-
-
+Further information and specific topics on [Editor JavaScript](frontend-javascript.html)
 
 <br><br>

--- a/source/documentation/services/editor/javascript.html.md.erb
+++ b/source/documentation/services/editor/javascript.html.md.erb
@@ -1,23 +1,15 @@
 ---
-title: Editor
-category: platform
+title: Editor - Custom Javascript
+category: platform-editor
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---
 
 <% if current_page.url != "/" %># <%= current_page.data.title %><% end %>
 
-Category: [Editor](../editor.html)
-
-* * * 
-
-# Javascript
 Custom javascript frontend, blah, blah and something more...
 
 ## Components
 
 * [Activated Menu](./javascript/component-activated-menu.html)
 * [Branch](./javascript/component-branch.html)
-
-
-<br><br>

--- a/source/documentation/services/editor/javascript/component-activated-menu.html.md.erb
+++ b/source/documentation/services/editor/javascript/component-activated-menu.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Activated Menu Component
-category: platform
+category: platform-editor-javascript
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---
@@ -192,7 +192,7 @@ Inside the `menuselect` event listener already in place on the initial `<ul>` el
 |String |undefined |Yes |
 
 ```
-new ActivatedMenu($("ul.menu"), { 
+new ActivatedMenu($("ul.menu"), {
   selection_event: "label-to-identify-menu-selection-event"
 });
 
@@ -206,7 +206,7 @@ When the passed selection event is triggered, the ***ActivatedMenu*** functional
 ```
 // Event data available
 
-{ 
+{
   activator: <the item that was clicked>,
   menu: <the original UL element>,
   component: <the actual ActivatedMenu instance>,

--- a/source/documentation/services/editor/javascript/component-branch.html.md.erb
+++ b/source/documentation/services/editor/javascript/component-branch.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Branch Component
-category: platform
+category: platform-editor-javascript
 last_reviewed_on: 2022-03-10
 review_in: 3 months
 ---


### PR DESCRIPTION
Updated recent effort to create some FE documentation.
This is just basic overview stuff but it's a start. 
Pages involved:

/documentation/services/editor/frontend-overview.html
/documentation/services/editor/frontend-html.html
/documentation/services/editor/frontend-css.html
/documentation/services/editor/frontend-javascript.html
