### PR TITLE
Make htmlproofer ignore kibana link it cannot access

### DIFF
--- a/source/documentation/runbooks/delayed-job-failures.html.md.erb
+++ b/source/documentation/runbooks/delayed-job-failures.html.md.erb
@@ -10,7 +10,7 @@ Form Builder submissions are put onto a queue to be processed by the Submitter. 
 
 ### Find the correct environment
 
-Sometimes the environment the alert ocurred in does not get outputted to Slack. You can check the Form Builder [Grafana dashboard](https://grafana.cloud-platform.service.justice.gov.uk/d/-hXgWMWWk/form-builder?orgId=1) to see where it occurred. Failed Submitter Delayed Jobs is the top left box. Toggle the `platform_env` and `deployment_env` to move between environments.
+Sometimes the environment the alert ocurred in does not get outputted to Slack. You can check the Form Builder <div data-proofer-ignore>[Grafana dashboard](https://grafana.cloud-platform.service.justice.gov.uk/d/-hXgWMWWk/form-builder?orgId=1)</div> to see where it occurred. Failed Submitter Delayed Jobs is the top left box. Toggle the `platform_env` and `deployment_env` to move between environments.
 
 ### Locate a Submitter API pod
 

--- a/source/documentation/runbooks/reviewing-kibana-logs.html.md.erb
+++ b/source/documentation/runbooks/reviewing-kibana-logs.html.md.erb
@@ -8,7 +8,7 @@ review_in: 6 months
 
 The Formbuilder platform exports all Kubernetes logs to Kibana, but it can be difficult to filter out the noise and find exactly what you need.
 
-Start with this [pregenerated search](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/goto/1ae2f0e0ed627fca79561d62c0c822fc)
+Start with this <div data-proofer-ignore>[pregenerated search](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/goto/1ae2f0e0ed627fca79561d62c0c822fc)</div>
 
 This query filters out a number of common info logs such as metrics and healthcheck calls using `log is not`. 
 

--- a/source/documentation/services/runner.html.md.erb
+++ b/source/documentation/services/runner.html.md.erb
@@ -80,7 +80,7 @@ The resulting token must be passed as a header called `x-access-token`
 
 Acceptance tests for both the new Runner and the Legacy Runner can be found in the [fb-acceptance-tests](https://github.com/ministryofjustice/fb-acceptance-tests) repo. All the forms that are tested against live in the `formbuilder-services-test-dev` namespace.
 
-The Legacy Runner makes use of several forms each broken down to test an individual component. They can be found in the [test Publisher](https://fb-publisher-test.apps.live.cloud-platform.service.justice.gov.uk/services?utf8=%E2%9C%93&query=acceptance).
+The Legacy Runner makes use of several forms each broken down to test an individual component. They can be found in the <div data-proofer-ignore>[test Publisher](https://fb-publisher-test.apps.live.cloud-platform.service.justice.gov.uk/services?utf8=%E2%9C%93&query=acceptance)</div>.
 
 There are quite a few forms:
 


### PR DESCRIPTION
Reopening as failed to deploy with the link checker unable to access the kibana query as it is behind oAuth