### PR TITLE
Bump tech-docs-github-pages-publisher

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
+      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
     steps:
     - uses: actions/checkout@v3
     - name: htmlproofer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
+      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Compile Markdown to HTML and create artifact
-      run: /scripts/deploy.sh
+      run: /usr/local/bin/package
     - name: Upload artifact to be published
       uses: actions/upload-artifact@v3
       with:

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview
@@ -7,4 +7,4 @@ preview:
 		-v $$(pwd)/config:/app/config \
 		-v $$(pwd)/source:/app/source \
 		-p 4567:4567 \
-		-it $(IMAGE) /scripts/preview.sh
+		-it $(IMAGE) /usr/local/bin/preview


### PR DESCRIPTION
Updated the path to the scripts, as they have changed in this version of the publisher.

The tudor crown is part of the new version too.