### PR TITLE
Revert to v3.0.2 and hide crown logo

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
     steps:
     - uses: actions/checkout@v3
     - name: htmlproofer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
     permissions:
       contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Compile Markdown to HTML and create artifact
-      run: /usr/local/bin/package
+      run: /scripts/deploy.sh
     - name: Upload artifact to be published
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,7 +2,7 @@
 host: https://ministryofjustice.github.io/moj-forms-tech-docs
 
 # Header-related options
-show_govuk_logo: true
+show_govuk_logo: false
 service_name: MOJ Forms Tech Docs
 service_link: '#moj-forms-tech-docs'
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:v3.0.2
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview
@@ -7,4 +7,4 @@ preview:
 		-v $$(pwd)/config:/app/config \
 		-v $$(pwd)/source:/app/source \
 		-p 4567:4567 \
-		-it $(IMAGE) /usr/local/bin/preview
+		-it $(IMAGE) /scripts/preview.sh


### PR DESCRIPTION
tech-docs-github-pages-publisher v4.0.0 seems to have a breaking change in the way urls are generated, producing breaking urls for assets.

In the meantime until that is solved, keep the previous version, but hide the crown logo, as should be the case for this site anyways.