### PR TITLE
[CDPTKAN-256] fb-submitter JWE Webhook destination err

### DIFF
--- a/source/documentation/runbooks/alerts-quick-guide.html.md.erb
+++ b/source/documentation/runbooks/alerts-quick-guide.html.md.erb
@@ -132,6 +132,22 @@ Due to the age of the error when investigating (>28 days), the exact cause is no
 
 If it was a normal run, a stale token past the 90 second skew window might be the cause. If it was a replay, the token skew has been overridden to 28 days.
 
+### Adapters::JweWebhookDestination:: ClientRequestError -> Prawn::Errors::UnknownFont
+This appears as a `422` from `Adapters::JweWebhookDestination#send_webhook` when `V2::ProcessSubmissionJob` posts to `https://track-a-query.service.justice.gov.uk/api/rpi`. The `422` is the symptom. `Api::RpiController#create` on track-a-query catches an exception and returns `head :unprocessable_entity`.
+
+The real error in track-a-query is `Prawn::Errors::UnknownFont`, raised in `RequestPersonalInformation::FileBuilder#zip_pdf` while generating the submission's PDF. To handle arbitrary submitted characters, the PDF uses a fallback font, "LastResort", but only a `normal` style is registered:
+
+```ruby
+pdf.font_families.update(
+  "LastResort" => { normal: LAST_RESORT_FONT_FILE },
+)
+pdf.fallback_fonts(%w[LastResort])
+```
+
+If the submitted content (`rpi.to_markdown(target)`) needs italics, Prawn looks for an italic "LastResort" that doesn't exist, and raises instead of generating the PDF.
+
+A potential fix would be to add the italic font by including `italic: LAST_RESORT_FONT_FILE`.
+
 ### There is a Sentry alert - how do I find out which form is causing the error?
 When a Sentry alert is triggered, general information regarding the alert can be accessed via the [Sentry dashboard](https://sentry.io/organizations/ministryofjustice/issues/). There will be a URL that is provided in the Sentry Issue, this will have the service ID in the path.
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/projects/CDPTKAN/boards/6617?filter=%22Team%5BTeam%5D%22%20%3D%20242b5860-a667-4889-b148-5a45e0f9c89b%0AAND%20assignee%20%3D%20712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&groupBy=none&selectedIssue=CDPTKAN-256

The error is raised downstream in track-a-query (CT Staff) when building a PDF. Prawn's font_families hash has no `italic` key registered

<img width="833" height="640" alt="Screenshot 2026-08-04 at 11 20 41" src="https://github.com/user-attachments/assets/af1fa354-74c8-4777-9b9d-f871edebe990" />
