### PR TITLE
[CDPTKAN-263] fb-editor Error: cannot call methods on dialog

### DIFF
--- a/source/documentation/runbooks/alerts-quick-guide.html.md.erb
+++ b/source/documentation/runbooks/alerts-quick-guide.html.md.erb
@@ -176,6 +176,16 @@ The page is trying to draw an arrow to its "next" page, but that page isn't in t
 
 This is already caught and reported via `view.sentry.send(err)`, so it does not break the page, it just skips drawing that one arrow leaving a detached branch with a missing line.
 
+### Error: cannot call methods on dialog prior to initialization; attempted to call method 'open'
+
+This is raised in fb-editor at `app/javascript/src/component_dialog_api_request.js` when `open()` is called on a dialog that no longer exists.
+
+Dialogs in the Editor are ephemeral, a new `DialogApiRequest` is created each time an action is triggered, and the dialog is destroyed and removed from the DOM when it closes.
+
+The activator (the link or button that opens the dialog, for example "Delete page..." in the page menu) is not destroyed with it. When the same activator is used again, the click listener added for the previous dialog is still attached and calls `open()` on that now-destroyed dialog, which throws this error.
+
+The user does not see a problem and the new dialog still opens correctly, but the stale call is reported to Sentry. It only occurs from the second time onwards when the activator is used.
+
 ### There is a Sentry alert - how do I find out which form is causing the error?
 When a Sentry alert is triggered, general information regarding the alert can be accessed via the [Sentry dashboard](https://sentry.io/organizations/ministryofjustice/issues/). There will be a URL that is provided in the Sentry Issue, this will have the service ID in the path.
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/projects/CDPTKAN/boards/6617?filter=%22Team%5BTeam%5D%22%20%3D%20242b5860-a667-4889-b148-5a45e0f9c89b%0AAND%20assignee%20%3D%20712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&groupBy=none&selectedIssue=CDPTKAN-263

A potential fix for this issue is to edit https://github.com/ministryofjustice/fb-editor/blob/main/app/javascript/src/component_dialog_activator.js with the below. Use the `var generated...` to record whether this class created the element. 

```
class DialogActivator {
  constructor($node, config) {
    var conf = utilities.mergeObjects({
      text: "",
      classes: ""
    }, config);
    var generated = false;

    if(!$node || !($node instanceof jQuery && $node.length)) {
      $node = this.#createActivator(conf.$target, conf.text);
      generated = true;
    }

    $node.data("instance", this);
    $node.addClass("DialogActivator");
    $node.addClass(config.classes);
    $node.removeAttr('hidden');

    // Only bind if we generated this element. An existing node passed in by
    // the caller already has its own handling that creates the dialog.
    if (generated) {
      $node.on("click.DialogActivator", (e) => {
        if (e.target.getAttribute("aria-disabled") === "true") return;
        this.dialog.open();
      });
    }
...
}

```
To reproduce the error. Open the same page dialog box more than once, which will then show the error in the browser console
<img width="1315" height="646" alt="Screenshot 2026-08-06 at 14 31 52" src="https://github.com/user-attachments/assets/c65fb79f-466b-404d-a8d3-901e9fcc020c" />


After
<img width="296" height="158" alt="Screenshot 2026-08-06 at 14 29 36" src="https://github.com/user-attachments/assets/e6120e56-076b-4452-8ad9-2b8a12b3dab6" />

